### PR TITLE
[story/TP-94583]: Fix datamapper-do/do-mysql install and compile failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ tmtags
 ## Rubinius
 *.rbc
 
+## RubyMine
+.idea
+
 ## PROJECT::GENERAL
 *.gem
 coverage

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ SOURCE         = ENV.fetch('SOURCE', :git).to_sym
 REPO_POSTFIX   = SOURCE == :path ? ''                                : '.git'
 DATAMAPPER     = SOURCE == :path ? Pathname(__FILE__).dirname.parent : 'http://github.com/datamapper'
 DM_VERSION     = '~> 1.3.0.beta'
-DO_VERSION     = '~> 0.10.6'
+DO_VERSION     = '~> 0.10.17'
 CURRENT_BRANCH = ENV.fetch('GIT_BRANCH', 'master')
 
 do_options = {}

--- a/dm-sqlite-adapter.gemspec
+++ b/dm-sqlite-adapter.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.version       = DataMapper::SqliteAdapter::VERSION
 
   gem.add_runtime_dependency('dm-do-adapter', [ '~> 1.3.0.beta' ])
-  gem.add_runtime_dependency('do_sqlite3',    [ '~> 0.10.6'     ])
+  gem.add_runtime_dependency('do_sqlite3',    [ '~> 0.10.17'     ])
 
   gem.add_development_dependency('dm-migrations', [ '~> 1.3.0.beta' ])
   gem.add_development_dependency('rake',          [ '~> 0.9.2'      ])


### PR DESCRIPTION
# Topic

TargetProcess Link: https://sbf.tpondemand.com/entity/94583

## How to test
* [How to PR](https://github.com/firespring/sbf/blob/master/documentation/guides/processes/pull_requests.md#reviewing-pull-requests)

### Functionality
* Update to use correct version of data_objects gems
* Update Gemfile to correctly account for differences in env variables for different gems and to use git branches when configured.
* Ignore ide files

### PRs for this story from other repos
* [dm-dev](https://github.com/firespring/dm-dev/pull/4)
* data_mapper - No changes 
* [datamapper-do](https://github.com/firespring/datamapper-do/pull/5)
* [dm-aggregates] - No changes
* [dm-constraints] - No changes
* [dm-core] - No changes
* [dm-do-adapter](https://github.com/firespring/dm-do-adapter/pull/4)
* [dm-mysql-adapter](https://github.com/firespring/dm-mysql-adapter/pull/4)
* [dm-noisy-failures] - No changes
* [dm-serializer] - No changes
* **dm-sqlite-adapter - This PR**
* [dm-timestamps] - No changes
* [dm-transactions] - No changes
* [dm-types] - No changes
* [dm-validations] - No changes